### PR TITLE
make running the app for local development easier.

### DIFF
--- a/FakebookNotifications/FakebookNotifications.DataAccess/NotificationsContext.cs
+++ b/FakebookNotifications/FakebookNotifications.DataAccess/NotificationsContext.cs
@@ -55,7 +55,7 @@ namespace FakebookNotifications.DataAccess
 
             try
             {
-                List<Notification> davidNotes = noteCol.Find(x => x.LoggedInUserId == "david.barnes@revature.net").ToList();
+                List<Notification> davidNotes = noteCol.Find(x => x.LoggedInUserId == "john.werner@revature.net").ToList();
                 List<Notification> testNotes = noteCol.Find(x => x.LoggedInUserId == "testaccount@gmail.com").ToList();
 
 
@@ -89,7 +89,7 @@ namespace FakebookNotifications.DataAccess
                 //Create seed users
                 User user1 = new()
                 {
-                    Email = "david.barnes@revature.net"
+                    Email = "john.werner@revature.net"
                 };
                 User user2 = new()
                 {
@@ -119,7 +119,7 @@ namespace FakebookNotifications.DataAccess
                 Notification note1 = new()
                 {
                     Type = new KeyValuePair<string, int>("post", 1),
-                    LoggedInUserId = "david.barnes@revature.net",
+                    LoggedInUserId = "john.werner@revature.net",
                     TriggerUserId = "testaccount@gmail.com",
                     HasBeenRead = false,
                     Date = DateTime.Now
@@ -127,7 +127,7 @@ namespace FakebookNotifications.DataAccess
                 Notification note2 = new()
                 {
                     Type = new KeyValuePair<string, int>("follow", 0),
-                    LoggedInUserId = "david.barnes@revature.net",
+                    LoggedInUserId = "john.werner@revature.net",
                     TriggerUserId = "testaccount@gmail.com",
                     HasBeenRead = true,
                     Date = DateTime.Now
@@ -135,7 +135,7 @@ namespace FakebookNotifications.DataAccess
                 Notification note3 = new()
                 {
                     Type = new KeyValuePair<string, int>("like", 15),
-                    LoggedInUserId = "david.barnes@revature.net",
+                    LoggedInUserId = "john.werner@revature.net",
                     TriggerUserId = "testaccount@gmail.com",
                     HasBeenRead = false,
                     Date = DateTime.Now
@@ -144,7 +144,7 @@ namespace FakebookNotifications.DataAccess
                 {
                     Type = new KeyValuePair<string, int>("post", 4),
                     LoggedInUserId = "testaccount@gmail.com",
-                    TriggerUserId = "david.barnes@revature.net",
+                    TriggerUserId = "john.werner@revature.net",
                     HasBeenRead = false,
                     Date = DateTime.Now
                 };

--- a/FakebookNotifications/FakebookNotifications.WebApi/Properties/launchSettings.json
+++ b/FakebookNotifications/FakebookNotifications.WebApi/Properties/launchSettings.json
@@ -22,7 +22,7 @@
       "dotnetRunMessages": "true",
       "launchBrowser": true,
       "launchUrl": "swagger",
-      "applicationUrl": "https://localhost:5001;http://localhost:5000",
+      "applicationUrl": "https://localhost:44345;http://localhost:56003",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/FakebookNotifications/FakebookNotifications.WebApi/Startup.cs
+++ b/FakebookNotifications/FakebookNotifications.WebApi/Startup.cs
@@ -55,7 +55,7 @@ namespace FakebookNotifications.WebApi
             }
             ).AddJwtBearer(options =>
             {
-                options.Authority = "https://dev-2875280.okta.com/oauth2/default";
+                options.Authority = "https://revature-p3.okta.com/oauth2/default";
                 options.Audience = "api://default";
                 options.Events = new JwtBearerEvents
                 {

--- a/FakebookNotifications/FakebookNotifications.WebApi/appsettings.Development.json
+++ b/FakebookNotifications/FakebookNotifications.WebApi/appsettings.Development.json
@@ -1,4 +1,7 @@
 {
+  "NotificationsDatabaseSettings": {
+    "ConnectionString": "mongodb://localhost:27017"
+  },
   "Logging": {
     "LogLevel": {
       "Default": "Information",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@
 # run in foreground: `docker-compose up`
 # run in background: `docker-compose up -d`
 # stop in background: `docker-compose down`
-# reset the db volume: `docker-compose down -v`
+# reset the db: `docker-compose down -v && docker-compose build`
 
 services:
   db:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+﻿version: '3'
+
+# run in foreground: `docker-compose up`
+# run in background: `docker-compose up -d`
+# stop in background: `docker-compose down`
+# reset the db volume: `docker-compose down -v`
+
+services:
+  db:
+    image: mongo:4.4
+    ports:
+    - 27017:27017
+    volumes:
+    - db-data:/data/db
+
+volumes:
+  db-data:


### PR DESCRIPTION
- add docker-compose file for the database. the service itself can be run outside docker.
- replace old okta configuration with new okta configuration (https://revature-p3-admin.okta.com/)
- replace old seed data based on old David account in okta with new John account in okta
- changed launchSettings so `dotnet run` uses the same ports that Visual Studio would: we can't run multiple services if they all want to be on port 5001.

cf. https://github.com/2011-fakebook-project3/profile/pull/36, https://github.com/2011-fakebook-project3/ng/pull/65, https://github.com/2011-fakebook-project3/posts/pull/114